### PR TITLE
Initial CI/CD Pipeline

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,31 @@
+name: Test Play-Go
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os:
+        - "ubuntu-latest"
+        - "macos-latest"
+        - "windows-latest"
+        version:
+        - "1.22"
+        - "1.23"
+      runs-on: ${{ matrix.os }}
+      steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.version }}
+
+      - name: Test
+        run: go test -v ./...

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.version }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,14 +18,14 @@ jobs:
         version:
         - "1.22"
         - "1.23"
-      runs-on: ${{ matrix.os }}
-      steps:
-      - uses: actions/checkout@v4
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ matrix.version }}
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ matrix.version }}
 
-      - name: Test
-        run: go test -v ./...
+    - name: Test
+      run: go test -v ./...

--- a/e2e_tests/testdata/scripts/basic.txtar
+++ b/e2e_tests/testdata/scripts/basic.txtar
@@ -2,5 +2,5 @@
 
 # Running playgo with no arguments produces a new scratchpad
 exec playgo
-stdout 'Created main.go in directory \".*\/.*\"'
+stdout 'Created main.go in directory'
 ! stderr .


### PR DESCRIPTION
This merge adds an initial CI/CD pipeline file to run tests on PRs and pushes to `main`, along with a workflow dispatch trigger. Tests execute on Windows, Ubuntu, and MacOS, with the latest couple versions of Go (1.22, 1.23).

The regex previously used to match output in end-to-end tests worked for unix-based systems, but was incorrect for Windows. Rather than introducing conditional checks to the test, the regex has been simplified to pass on all platforms.