### PR TITLE
Add Common Data Directory Lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,15 @@ and available on your `$PATH`. As such, the best installation method is:
 ## Usage
 
 Using Play-Go is (hopefully!) simple. If you run the command `playgo`, you
-should get directory called `scratches/<some-silly-name>` created in the
-directory where you currently are. This location will be changing to a
-more consistent location later on, in a new version, likely under
-`$XDG_DATA_HOME`. Usage information will be updated at that time.
+should get directory called `scratches/<some-silly-name>` created in one of 
+the following locations (in order):
+
+1. If you have `$XDG_DATA_HOME` set, `$XDG_DATA_HOME/scratches` will be used.
+2. If you have a home directory set (for example, `$HOME` on Unix/Linux/Darwin
+systems or `$USERPROFILE` or `%userprofile%` on Windows), then
+`<home>/.local/share/scratches` will be used.
+3. If neither of those are set, then the `scratches` directory will be put
+into whatever your current working directory is.
 
 > Note: Play-Go requires that you have Go installed and available on your `$PATH`.
 

--- a/e2e_tests/testdata/scripts/basic.txtar
+++ b/e2e_tests/testdata/scripts/basic.txtar
@@ -4,6 +4,7 @@
 # XDG_DATA_HOME takes priority
 env XDG_DATA_HOME=$WORK/xdg_data_home
 env HOME=$WORK/home
+[windows] env USERPROFILE=$HOME
 
 ! exists $WORK/xdg_data_home/scratches
 ! exists $WORK/home/.local/share/scratches
@@ -26,6 +27,7 @@ rm $WORK/scratches
 # $HOME/.local/share is used if XDG_DATA_HOME is unset
 env XDG_DATA_HOME=
 env HOME=$WORK/home
+[windows] env USERPROFILE=$HOME
 
 ! exists $WORK/xdg_data_home/scratches
 ! exists $WORK/home/.local/share/scratches
@@ -48,6 +50,7 @@ rm $WORK/scratches
 # local directory is used if neither XDG_DATA_HOME nor HOME are set
 env XDG_DATA_HOME=
 env HOME=
+[windows] env USERPROFILE=$HOME
 
 ! exists $WORK/xdg_data_home/scratches
 ! exists $WORK/home/.local/share/scratches

--- a/e2e_tests/testdata/scripts/basic.txtar
+++ b/e2e_tests/testdata/scripts/basic.txtar
@@ -1,6 +1,66 @@
 # Basic usage tests
 
-# Running playgo with no arguments produces a new scratchpad
+# Running playgo with no arguments produces a scratchpad
+# XDG_DATA_HOME takes priority
+env XDG_DATA_HOME=$WORK/xdg_data_home
+env HOME=$WORK/home
+
+! exists $WORK/xdg_data_home/scratches
+! exists $WORK/home/.local/share/scratches
+! exists $WORK/scratches
+
 exec playgo
 stdout 'Created main.go in directory'
 ! stderr .
+
+exists $WORK/xdg_data_home/scratches
+! exists $WORK/home/.local/share/scratches
+! exists $WORK/scratches
+
+# Clean up data directories
+rm $WORK/xdg_data_home/scratches 
+rm $WORK/home/.local/share/scratches
+rm $WORK/scratches
+
+# Running playgo with no arguments produces a scratchpad
+# $HOME/.local/share is used if XDG_DATA_HOME is unset
+env XDG_DATA_HOME=
+env HOME=$WORK/home
+
+! exists $WORK/xdg_data_home/scratches
+! exists $WORK/home/.local/share/scratches
+! exists $WORK/scratches
+
+exec playgo
+stdout 'Created main.go in directory'
+! stderr .
+
+! exists $WORK/xdg_data_home/scratches
+exists $WORK/home/.local/share/scratches
+! exists $WORK/scratches
+
+# Clean up data directories
+rm $WORK/xdg_data_home/scratches 
+rm $WORK/home/.local/share/scratches
+rm $WORK/scratches
+
+# Running playgo with no arguments produces a scratchpad
+# local directory is used if neither XDG_DATA_HOME nor HOME are set
+env XDG_DATA_HOME=
+env HOME=
+
+! exists $WORK/xdg_data_home/scratches
+! exists $WORK/home/.local/share/scratches
+! exists $WORK/scratches
+
+exec playgo
+stdout 'Created main.go in directory'
+
+! exists $WORK/xdg_data_home/scratches
+! exists $WORK/home/.local/share/scratches
+exists $WORK/scratches
+
+# Clean up data directories
+rm $WORK/xdg_data_home/scratches 
+rm $WORK/home/.local/share/scratches
+rm $WORK/scratches


### PR DESCRIPTION
This merge adds a common data directory lookup process rather than defaulting to the local directory. It will start with `XDG_DATA_HOME`, then look for a home directory, and only if both of those fails will it move on to the local directory.